### PR TITLE
SrcTag replace is not working because of typo.

### DIFF
--- a/build/js/jquery.fireSlider.js
+++ b/build/js/jquery.fireSlider.js
@@ -315,7 +315,7 @@
             if (result.search(srcTag) !== -1) {
                 var img = slide.querySelectorAll('img')[0];
                 var src = (typeof img !== "undefined") ? img.src : '';
-                result = result.replace(numTag, src);
+                result = result.replace(srcTag, src);
             }
 
             var descriptionTag = this.getTemplateTagRegex('description');


### PR DESCRIPTION
I want to use {{ src }} in template but srcTag was not working because of typo.
Please merge this to fix this bug.